### PR TITLE
Split out Renewed and Disabled Contracts for 1.4.0 benchmark

### DIFF
--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -21,7 +21,8 @@ type Metrics struct {
 	FileUploadedBytes          uint64 `csv:"file_uploaded_bytes"`
 
 	ContractCountActive      int            `csv:"contract_count_active"`
-	ContractCountInactive    int            `csv:"contract_count_inactive"`
+	ContractCountRenewed     int            `csv:"contract_count_renewed"`
+	ContractCountDisabled    int            `csv:"contract_count_disabled"`
 	ContractTotalSize        uint64         `csv:"contract_total_size"`
 	ContractTotalSpending    types.Currency `csv:"contract_total_spending"`
 	ContractFeeSpending      types.Currency `csv:"contract_fee_spending"`


### PR DESCRIPTION
`renewedContracts` are contracts that you current have an active contract with that host. The spending is accurate but the data ends up being double counted so we remove those from the contract size summation.

`disabledContracts` are contracts that were not renewed and are no longer active so that is real original data that was uploaded.